### PR TITLE
2025/boot_imx93.sh: modify PATH to be able to use local uuu

### DIFF
--- a/2025/boot_imx93.sh
+++ b/2025/boot_imx93.sh
@@ -56,6 +56,8 @@ pad_to_4096 "_Image"
 pad_to_4096 "_dtb"
 pad_to_4096 "_rootfs"
 
+# Add cwd to $PATH to be able to use the local uuu
+PATH=$PATH:$(pwd)
 # Run uuu
 echo "Running uuu..."
 uuu -b emmc_boot "$FLASH_BIN" "_rootfs" "_Image" "_dtb"


### PR DESCRIPTION
The `uuu` tool is necessary for running this script, and while it is provided locally, the script was unable to find it and was throwing `"uuu command not found"`. This commit fixes that by modifying `PATH` for the duration of the script. The alternative would have been to use `./uuu`, however this approach seems cleaner to me.

This is an issue I had initially associated to the docs repo [here](https://github.com/Linux-Kernel-Summer-School/docs/issues/13). After finding the actual problem, thanks to [LaurentiuM1234](https://github.com/LaurentiuM1234), I managed to modify this script to work using the local version of `uuu`